### PR TITLE
support for Alchemy RPC

### DIFF
--- a/lib/apiclient.js
+++ b/lib/apiclient.js
@@ -53,7 +53,7 @@ export default class EthRPC {
         atBlock = atBlock || "latest";
         start = start || 0;
         num = num || 1;
-        let params = [...Array(num).keys()].map((idx) => [target, (start + idx).toString(16), atBlock])
+        let params = [...Array(num).keys()].map((idx) => [target, "0x"+(start + idx).toString(16), atBlock])
         return this.callBatch("eth_getStorageAt", params);
     }
 


### PR DESCRIPTION
Alchemy's RPC implementation requires the hex value quantity to start with "0x".