### PR TITLE
fix: Add arbitrary slot support

### DIFF
--- a/lib/apiclient.js
+++ b/lib/apiclient.js
@@ -48,12 +48,25 @@ export default class EthRPC {
     }
 
     getStorageAt(target, start, num, atBlock) {
-        start = parseInt(start.replace("0x", ""), 16)
+        let tmpStart = start.replace("0x", "");
+        start = parseInt(tmpStart, 16);
 
         atBlock = atBlock || "latest";
-        start = start || 0;
-        num = num || 1;
-        let params = [...Array(num).keys()].map((idx) => [target, "0x"+(start + idx).toString(16), atBlock])
+
+        let params;
+
+        if (start.toString(16) !== tmpStart) {
+            // overflow
+            params = [[target, "0x" + tmpStart, atBlock]];
+        } else {
+            start = start || 0;
+            num = num || 1;
+            params = [...Array(num).keys()].map((idx) => [
+                target,
+                "0x" + (start + idx).toString(16),
+                atBlock,
+            ]);
+        }
         return this.callBatch("eth_getStorageAt", params);
     }
 

--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -109,12 +109,20 @@ function analyzeSlot(arr, slotNr) {
 }
 
 function analyzeStorage(state) {
-    let startSlot = parseInt(state.startslot.replace("0x", ""), 16)
+    let startSlot = parseInt(state.startslot.replace("0x", ""), 16);
     let i = 0;
     let ret = {};
+
     for (let slotBytes of chop(state.data, 32)) {
-        let currSlot = `slot: 0x${(startSlot + i).toString(16)} (0x${(startSlot + i * 32).toString(16)})`;
-        ret[currSlot] = analyzeSlot(slotBytes, startSlot + i);
+        if (i === 0) {
+            ret[`slot: ${state.startslot}`] = analyzeSlot(slotBytes, 0);
+        } else {
+            let currSlot = `slot: 0x${(startSlot + i).toString(16)} (0x${(
+                startSlot +
+                i * 32
+            ).toString(16)})`;
+            ret[currSlot] = analyzeSlot(slotBytes, startSlot + i);
+        }
         i++;
     }
     return ret;


### PR DESCRIPTION
Currently, the implementation cannot get arbitrary storage slot due to JS big integer truncation.

For a quick fix, limited the number to 1 when overflow occurs.

For long-term fix, it's recommended to use BigInt.